### PR TITLE
【Fixed】コメント機能に制限をかけたIssues/#31

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -18,8 +18,12 @@ class CommentsController < ApplicationController
   def edit
     @comment = @health.comments.find(params[:id])
     respond_to do |format|
-      flash.now[:notice] = 'コメントの編集中'
-      format.js { render :edit }
+      if @comment.user == current_user
+        flash.now[:notice] = 'コメントの編集中'
+        format.js { render :edit }
+      else
+        format.js { render :index }
+      end
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,6 +3,7 @@ class CommentsController < ApplicationController
 
   def create
     @comment = @health.comments.build(comment_params)
+    @comment.user_id = current_user.id
 
     respond_to do |format|
       if @comment.save
@@ -47,7 +48,7 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:content)
+    params.require(:comment).permit(:content, :user_id)
   end
 
   def set_health

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -42,9 +42,13 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment = Comment.find(params[:id])
-    @comment.destroy
-    respond_to do |format|
-      flash.now[:notice] = 'コメントが削除されました'
+    if @comment.user == current_user
+      @comment.destroy
+      respond_to do |format|
+        flash.now[:notice] = 'コメントが削除されました'
+        format.js { render :index }
+      end
+    else
       format.js { render :index }
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :health
+  belongs_to :user
   validates :content, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,7 @@ class User < ApplicationRecord
   # has_many :care_users. optional :true
   has_many :care_users
   has_many :reserves
+  has_many :comments
 
   VALID_PHONE_NUMBER_REGEX = /\A0(\d{1}[-(]?\d{4}|\d{2}[-(]?\d{3}|\d{3}[-(]?\d{2}|\d{4}[-(]?\d{1})[-)]?\d{4}\z|\A0[5789]0[-]?\d{4}[-]?\d{4}\z/
   validates :phone_number, format: { with: VALID_PHONE_NUMBER_REGEX }

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -7,9 +7,6 @@
         <p><%= comment.user.name %>：<%= comment.content %>
         <% if comment.user_id == current_user.id %>
           <%= link_to "編集", edit_health_comment_path(health, comment), remote: true %>
-        <% end %>
-
-        <% if current_user.owner_id == nil %>
           <%= link_to "削除", health_comment_path(comment.health_id, comment.id), method: :delete, remote: true,
             data: { confirm: "本当に削除しますか?"} %>
         <% end %>

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -5,8 +5,11 @@
       <li>
         <div class="comment-content" id ="this_comment_<%= comment.id %>"></div>
         <p><%= comment.user.name %>：<%= comment.content %>
-        <% if current_user.owner_id == nil %>
+        <% if comment.user_id == current_user.id %>
           <%= link_to "編集", edit_health_comment_path(health, comment), remote: true %>
+        <% end %>
+
+        <% if current_user.owner_id == nil %>
           <%= link_to "削除", health_comment_path(comment.health_id, comment.id), method: :delete, remote: true,
             data: { confirm: "本当に削除しますか?"} %>
         <% end %>

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -4,7 +4,7 @@
     <% if comment.id.present? %>
       <li>
         <div class="comment-content" id ="this_comment_<%= comment.id %>"></div>
-        <%= comment.content %>
+        <p><%= comment.user.name %>：<%= comment.content %>
         <% if current_user.owner_id == nil %>
           <%= link_to "編集", edit_health_comment_path(health, comment), remote: true %>
           <%= link_to "削除", health_comment_path(comment.health_id, comment.id), method: :delete, remote: true,

--- a/db/migrate/20221225143830_add_user_ref_to_comments.rb
+++ b/db/migrate/20221225143830_add_user_ref_to_comments.rb
@@ -1,0 +1,5 @@
+class AddUserRefToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :comments, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_24_154330) do
+ActiveRecord::Schema.define(version: 2022_12_25_143830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,7 +38,9 @@ ActiveRecord::Schema.define(version: 2022_12_24_154330) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
     t.index ["health_id"], name: "index_comments_on_health_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "healths", force: :cascade do |t|
@@ -110,6 +112,7 @@ ActiveRecord::Schema.define(version: 2022_12_24_154330) do
 
   add_foreign_key "care_users", "users"
   add_foreign_key "comments", "healths"
+  add_foreign_key "comments", "users"
   add_foreign_key "healths", "care_users"
   add_foreign_key "reserves", "users"
 end


### PR DESCRIPTION
- UserモデルとCommentモデルを1対多で関連付けをした
- コメント一覧に投稿したユーザの名前を表示
- 他人のコメントを編集、削除できないように制限をかけた