### PR TITLE
【WIP】責任者テーブルのCRUD機能作成Issues/#33

### DIFF
--- a/app/assets/stylesheets/managers.scss
+++ b/app/assets/stylesheets/managers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the managers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/healths_controller.rb
+++ b/app/controllers/healths_controller.rb
@@ -7,6 +7,7 @@ class HealthsController < ApplicationController
     @care_user = CareUser.find(params[:care_user_id])
     # @care_user = params[:care_user_id]
     # binding.pry
+    @managers = Manager.where(user_id: current_user.id)
   end
 
   def create

--- a/app/controllers/healths_controller.rb
+++ b/app/controllers/healths_controller.rb
@@ -4,10 +4,9 @@ class HealthsController < ApplicationController
   def new
     # byebug
     @health = Health.new
-    # binding.pry
     @care_user = CareUser.find(params[:care_user_id])
     # @care_user = params[:care_user_id]
-    # byebug
+    # binding.pry
   end
 
   def create
@@ -15,7 +14,6 @@ class HealthsController < ApplicationController
     # @health = @care_user.health.build(params[:id])
     # @health.care_user_id = @care_user.id
     # @care_user = @health.build_care_user(care_user_params)
-    # binding.pry
     if current_user.owner_id != nil
       if @health.save
         # binding.pry
@@ -80,7 +78,7 @@ class HealthsController < ApplicationController
   private
 
   def health_params
-    params.require(:health).permit(:record_in_at, :time, :blood_pressure_up, :blood_pressure_down, :pulse, :body_temperature, :breakfast, :lunch, :snack, :dinner, :before_sleep, :morning_medicine, :daytime_medicine, :snack_medicine, :evening_medicine, :sleep_medicine, :bath_time, :bath_division, :caregiver, :height, :body_weight, :daytime, :daytime_staff, :night, :night_staff, :contact, :contact_staff, :responsibility, :transfer, :care_user_id)
+    params.require(:health).permit(:record_in_at, :time, :blood_pressure_up, :blood_pressure_down, :pulse, :body_temperature, :breakfast, :lunch, :snack, :dinner, :before_sleep, :morning_medicine, :daytime_medicine, :snack_medicine, :evening_medicine, :sleep_medicine, :bath_time, :bath_division, :caregiver, :height, :body_weight, :daytime, :daytime_staff, :night, :night_staff, :contact, :contact_staff, :responsibility, :transfer, :care_user_id, { manager_ids: [] })
     # .merge(breakfast: params[:health][:breakfast].to_i, lunch: params[:health][:lunch].to_i, snack: params[:health][:snack].to_i, dinner: params[:health][:dinner].to_i, before_sleep: params[:health][:before_sleep].to_i, morning_medicine: params[:health][:morning_medicine].to_i, daytime_medicine: params[:health][:daytime_medicine].to_i, snack_medicine: params[:health][:snack_medicine].to_i, evening_medicine: params[:health][:evening_medicine].to_i, sleep_medicine: params[:health][:sleep_medicine].to_i, bath_division: params[:health][:bath_division].to_i)
   end
 

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -1,0 +1,2 @@
+class ManagersController < ApplicationController
+end

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -5,11 +5,15 @@ class ManagersController < ApplicationController
   end
 
   def create
-    @manager = Manager.new(manager_params)
-    if @manager.save
-      redirect_to managers_path
+    if current_user.owner_id != nil
+      @manager = Manager.new(manager_params)
+      if @manager.save
+        redirect_to managers_path
+      else
+        render :new
+      end
     else
-      render :new
+      redirect_to user_path(current_user.id)
     end
   end
 

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -24,10 +24,16 @@ class ManagersController < ApplicationController
   def update
     @manager = Manager.find(params[:id])
     if @manager.update(manager_params)
-      redirect_to managers_path, notice: "編集しました"
+      redirect_to managers_path, notice: "管理者名を編集しました"
     else
       render :edit
     end
+  end
+
+  def destroy
+    @manager = Manager.find(params[:id])
+    @manager.destroy
+    redirect_to managers_path, notice: "管理者を削除しました"
   end
 
   private

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -43,8 +43,12 @@ class ManagersController < ApplicationController
 
   def destroy
     @manager = Manager.find(params[:id])
-    @manager.destroy
-    redirect_to managers_path, notice: "管理者を削除しました"
+    if @manager.user_id == current_user.id
+      @manager.destroy
+      redirect_to managers_path, notice: "管理者を削除しました"
+    else
+      redirect_to managers_path
+    end
   end
 
   private

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -19,11 +19,8 @@ class ManagersController < ApplicationController
   end
 
   def index
-    if current_user.owner_id != nil
-      @managers = Manager.all
-    else
-      redirect_to user_path(current_user.id)
-    end
+    @managers = Manager.where(user_id: current_user.id)
+    # @managers = Manager.all
   end
 
   def edit

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -25,6 +25,11 @@ class ManagersController < ApplicationController
 
   def edit
     @manager = Manager.find(params[:id])
+    if @manager.user_id == current_user.id
+      render "edit"
+    else
+      redirect_to managers_path
+    end
   end
 
   def update

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -7,6 +7,7 @@ class ManagersController < ApplicationController
   def create
     if current_user.owner_id != nil
       @manager = Manager.new(manager_params)
+      @manager.user_id = current_user.id
       if @manager.save
         redirect_to managers_path
       else
@@ -47,6 +48,6 @@ class ManagersController < ApplicationController
   private
 
   def manager_params
-    params.require(:manager).permit(:name)
+    params.require(:manager).permit(:name, :user_id)
   end
 end

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -17,6 +17,19 @@ class ManagersController < ApplicationController
     @managers = Manager.all
   end
 
+  def edit
+    @manager = Manager.find(params[:id])
+  end
+
+  def update
+    @manager = Manager.find(params[:id])
+    if @manager.update(manager_params)
+      redirect_to managers_path, notice: "編集しました"
+    else
+      render :edit
+    end
+  end
+
   private
 
   def manager_params

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -1,2 +1,6 @@
 class ManagersController < ApplicationController
+
+  def new
+    @manager = Manager.new
+  end
 end

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -3,4 +3,23 @@ class ManagersController < ApplicationController
   def new
     @manager = Manager.new
   end
+
+  def create
+    @manager = Manager.new(manager_params)
+    if @manager.save
+      redirect_to managers_path
+    else
+      render :new
+    end
+  end
+
+  def index
+    @managers = Manager.all
+  end
+
+  private
+
+  def manager_params
+    params.require(:manager).permit(:name)
+  end
 end

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -18,7 +18,11 @@ class ManagersController < ApplicationController
   end
 
   def index
-    @managers = Manager.all
+    if current_user.owner_id != nil
+      @managers = Manager.all
+    else
+      redirect_to user_path(current_user.id)
+    end
   end
 
   def edit

--- a/app/helpers/managers_helper.rb
+++ b/app/helpers/managers_helper.rb
@@ -1,0 +1,2 @@
+module ManagersHelper
+end

--- a/app/models/health.rb
+++ b/app/models/health.rb
@@ -1,6 +1,8 @@
 class Health < ApplicationRecord
   belongs_to :care_user
   has_many :comments, dependent: :destroy
+  has_many :supervises, dependent: :destroy
+  has_many :managers, through: :supervises
 
   # enum breakfast: { 'ー':0, '全量':1, '半量':2, '1/3':3, '2/3':4, '1/4':5, '欠食':6, 'その他':7}, _prefix: true
   # enum lunch: { 'ー':0, '全量':1, '半量':2, '1/3':3, '2/3':4, '1/4':5, '欠食':6, 'その他':7}, _prefix: true

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -1,0 +1,2 @@
+class Manager < ApplicationRecord
+end

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -1,2 +1,4 @@
 class Manager < ApplicationRecord
+  has_many :supervises, dependent: :destroy
+  has_many :healths, through: :supervises
 end

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -1,4 +1,5 @@
 class Manager < ApplicationRecord
   has_many :supervises, dependent: :destroy
   has_many :healths, through: :supervises
+  belongs_to :user
 end

--- a/app/models/supervise.rb
+++ b/app/models/supervise.rb
@@ -1,0 +1,4 @@
+class Supervise < ApplicationRecord
+  belongs_to :health
+  belongs_to :manager
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ApplicationRecord
   has_many :care_users
   has_many :reserves
   has_many :comments
+  has_many :managers
 
   VALID_PHONE_NUMBER_REGEX = /\A0(\d{1}[-(]?\d{4}|\d{2}[-(]?\d{3}|\d{3}[-(]?\d{2}|\d{4}[-(]?\d{1})[-)]?\d{4}\z|\A0[5789]0[-]?\d{4}[-]?\d{4}\z/
   validates :phone_number, format: { with: VALID_PHONE_NUMBER_REGEX }

--- a/app/views/healths/_form.html.erb
+++ b/app/views/healths/_form.html.erb
@@ -21,7 +21,7 @@
     </div> -->
 
     <div>
-      <%= form.collection_check_boxes(:manager_ids, Manager.all, :id, :name) %>
+      <%= form.collection_check_boxes(:manager_ids, @managers, :id, :name) %>
     </div>
 
     <div>

--- a/app/views/healths/_form.html.erb
+++ b/app/views/healths/_form.html.erb
@@ -21,6 +21,7 @@
     </div> -->
 
     <div>
+      <%= form.collection_check_boxes(:manager_ids, Manager.all, :id, :name) %>
     </div>
 
     <div>

--- a/app/views/healths/_form.html.erb
+++ b/app/views/healths/_form.html.erb
@@ -14,9 +14,13 @@
   <%= form.hidden_field :care_user_id, :value => @care_user.id %>
 
   <div class="ggg">
+    <!-- 責任者名プルダウンリスト(配列として渡らず実装できず) -->
+    <!-- <div>
+      <label for="manager_name"><%#= Manager.human_attribute_name(:name) %></label>
+        <%#= form.collection_select(:manager_ids, Manager.all, :id, :name, { prompt: '選択してください' }) %>
+    </div> -->
+
     <div>
-      <%= form.label :responsibility, t('activerecord.attributes.health.responsibility') %>
-      <%= form.text_field :responsibility, :placeholder => "入力必須" %>
     </div>
 
     <div>

--- a/app/views/healths/index.html.erb
+++ b/app/views/healths/index.html.erb
@@ -23,7 +23,7 @@
         <% else %>
           <th><%= Health.human_attribute_name(:contact) %></th>
         <% end %>
-        <th><%= Health.human_attribute_name(:responsibility) %></th>
+        <th><%= Manager.human_attribute_name(:name) %></th>
       </tr>
     </thead>
 
@@ -56,7 +56,11 @@
               <td><%= health.contact.truncate(30) %></td>
             <% end %>
           <% end %>
-          <td><%= health.responsibility %></td>
+
+          <% health.managers.each do |manager| %>
+            <td><%= manager.name %></td>
+          <% end %>
+
           <td><%= link_to "詳細",health_path(health.id) %></td>
           <td>
             <% if current_user.owner_id != nil %>

--- a/app/views/healths/show.html.erb
+++ b/app/views/healths/show.html.erb
@@ -4,7 +4,12 @@
   <div class="form_c">
     <table class="table">
       <tr><th><%= Health.human_attribute_name(:record_in_at) %></th><td><%= @health.record_in_at&.strftime("%Y年 %m月 %d日") %></td></tr>
-      <tr><th><%= Health.human_attribute_name(:responsibility) %></th><td><%= @health.responsibility %></td></tr>
+      <tr>
+        <th><%= Manager.human_attribute_name(:name) %></th>
+          <% @health.managers.each do |manager| %>
+            <td><%= manager.name %></td>
+          <% end %>
+      </tr>
       <tr><th><%= Health.human_attribute_name(:time) %></th><td><%= @health.time&.strftime("%H:%M") %></td></tr>
       <tr><th><%= Health.human_attribute_name(:body_temperature) %></th><td><%= @health.body_temperature %></td></tr>
       <tr><th><%= Health.human_attribute_name(:blood_pressure_up) %></th><td><%= @health.blood_pressure_up %>/<%= @health.blood_pressure_down %></td></tr>

--- a/app/views/managers/edit.html.erb
+++ b/app/views/managers/edit.html.erb
@@ -9,3 +9,4 @@
     <%= form.submit %>
   </div>
 <% end %>
+<%= link_to "戻る", managers_path %>

--- a/app/views/managers/edit.html.erb
+++ b/app/views/managers/edit.html.erb
@@ -1,0 +1,11 @@
+<h3>責任者編集画面</h3>
+<%= form_with(model: @manager, local: true) do |form| %>
+  <div class="field">
+    <%= form.label :name, t('activerecord.attributes.manager.name') %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/managers/index.html.erb
+++ b/app/views/managers/index.html.erb
@@ -12,8 +12,8 @@
         <td><%= manager.name %></td>
         <% if manager.user_id == current_user.id %>
           <td><%= link_to "編集",edit_manager_path(manager.id) %></td>
+          <td><%= link_to "削除",manager_path(manager.id), method: :delete, data: {confirm: "本当に削除しますか？"} %></td>
         <% end %>
-        <td><%= link_to "削除",manager_path(manager.id), method: :delete, data: {confirm: "本当に削除しますか？"} %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/managers/index.html.erb
+++ b/app/views/managers/index.html.erb
@@ -11,6 +11,7 @@
       <tr>
         <td><%= manager.name %></td>
         <td><%= link_to "編集",edit_manager_path(manager.id) %></td>
+        <td><%= link_to "削除",manager_path(manager.id), method: :delete, data: {confirm: "本当に削除しますか？"} %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/managers/index.html.erb
+++ b/app/views/managers/index.html.erb
@@ -1,0 +1,16 @@
+<h3>責任者一覧</h3>
+<%= link_to "責任者新規作成", new_manager_path %>
+<table>
+  <thead>
+    <tr>
+      <th><%= Manager.human_attribute_name(:name) %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @managers.each do |manager| %>
+      <tr>
+        <td><%= manager.name %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/managers/index.html.erb
+++ b/app/views/managers/index.html.erb
@@ -1,5 +1,6 @@
 <h3>責任者一覧</h3>
-<%= link_to "責任者新規作成", new_manager_path %>
+<%= link_to "新規作成", new_manager_path %>
+<%= link_to "戻る", user_path(current_user.id) %>
 <table>
   <thead>
     <tr>

--- a/app/views/managers/index.html.erb
+++ b/app/views/managers/index.html.erb
@@ -10,7 +10,9 @@
     <% @managers.each do |manager| %>
       <tr>
         <td><%= manager.name %></td>
-        <td><%= link_to "編集",edit_manager_path(manager.id) %></td>
+        <% if manager.user_id == current_user.id %>
+          <td><%= link_to "編集",edit_manager_path(manager.id) %></td>
+        <% end %>
         <td><%= link_to "削除",manager_path(manager.id), method: :delete, data: {confirm: "本当に削除しますか？"} %></td>
       </tr>
     <% end %>

--- a/app/views/managers/index.html.erb
+++ b/app/views/managers/index.html.erb
@@ -10,6 +10,7 @@
     <% @managers.each do |manager| %>
       <tr>
         <td><%= manager.name %></td>
+        <td><%= link_to "編集",edit_manager_path(manager.id) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/managers/new.html.erb
+++ b/app/views/managers/new.html.erb
@@ -9,3 +9,4 @@
     <%= form.submit %>
   </div>
 <% end %>
+<%= link_to "戻る", managers_path %>

--- a/app/views/managers/new.html.erb
+++ b/app/views/managers/new.html.erb
@@ -1,0 +1,11 @@
+<h3>責任者登録</h3>
+<%= form_with(model: @manager, local: true) do |form| %>
+  <div class="field">
+    <%= form.label :name, t('activerecord.attributes.manager.name') %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,6 +33,9 @@
         <%= link_to reserves_path, class: "btn btn--orange btn-a" do %>
           カレンダー<p class="txt">ご家族が登録された面会などの予定を確認することができます</p>
         <% end %>
+        <%= link_to new_manager_path, class: "btn btn--orange btn-a" do %>
+          責任者登録<p class="txt">責任者一覧もこちらからアクセスできます</p>
+        <% end %>
       <% end %>
       <% if current_user.admin? %>
         <%= link_to rails_admin_path, class: "btn btn--orange btn-a" do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,8 +33,8 @@
         <%= link_to reserves_path, class: "btn btn--orange btn-a" do %>
           カレンダー<p class="txt">ご家族が登録された面会などの予定を確認することができます</p>
         <% end %>
-        <%= link_to new_manager_path, class: "btn btn--orange btn-a" do %>
-          責任者登録<p class="txt">責任者一覧もこちらからアクセスできます</p>
+        <%= link_to managers_path, class: "btn btn--orange btn-a" do %>
+          責任者一覧<p class="txt">責任者登録もこちらからアクセスできます</p>
         <% end %>
       <% end %>
       <% if current_user.admin? %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -109,6 +109,7 @@ ja:
       health: 'ヘルス情報'
       reserve: 'カレンダー'
       comment: 'コメント'
+      manager: '責任者'
     attributes:
       user:
         name: '名前'
@@ -174,6 +175,8 @@ ja:
         updated_at: '更新日時'
       comment:
         content: "コメント"
+      manager:
+        name: "責任者"
     errors:
       models:
         care_user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,5 @@ Rails.application.routes.draw do
     resources :comments
   end
   resources :reserves
+  resources :managers
 end

--- a/db/migrate/20221225165254_create_managers.rb
+++ b/db/migrate/20221225165254_create_managers.rb
@@ -1,0 +1,9 @@
+class CreateManagers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :managers do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221225170341_create_supervises.rb
+++ b/db/migrate/20221225170341_create_supervises.rb
@@ -1,0 +1,10 @@
+class CreateSupervises < ActiveRecord::Migration[6.1]
+  def change
+    create_table :supervises do |t|
+      t.references :health, foreign_key: true
+      t.references :manager, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221226104330_add_user_ref_to_managers.rb
+++ b/db/migrate/20221226104330_add_user_ref_to_managers.rb
@@ -1,0 +1,5 @@
+class AddUserRefToManagers < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :managers, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_25_143830) do
+ActiveRecord::Schema.define(version: 2022_12_25_165254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,12 @@ ActiveRecord::Schema.define(version: 2022_12_25_143830) do
     t.bigint "care_user_id"
     t.text "transfer"
     t.index ["care_user_id"], name: "index_healths_on_care_user_id"
+  end
+
+  create_table "managers", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "reserves", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_25_170341) do
+ActiveRecord::Schema.define(version: 2022_12_26_104330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,8 @@ ActiveRecord::Schema.define(version: 2022_12_25_170341) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_managers_on_user_id"
   end
 
   create_table "reserves", force: :cascade do |t|
@@ -129,6 +131,7 @@ ActiveRecord::Schema.define(version: 2022_12_25_170341) do
   add_foreign_key "comments", "healths"
   add_foreign_key "comments", "users"
   add_foreign_key "healths", "care_users"
+  add_foreign_key "managers", "users"
   add_foreign_key "reserves", "users"
   add_foreign_key "supervises", "healths"
   add_foreign_key "supervises", "managers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_25_165254) do
+ActiveRecord::Schema.define(version: 2022_12_25_170341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,15 @@ ActiveRecord::Schema.define(version: 2022_12_25_165254) do
     t.index ["user_id"], name: "index_reserves_on_user_id"
   end
 
+  create_table "supervises", force: :cascade do |t|
+    t.bigint "health_id"
+    t.bigint "manager_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["health_id"], name: "index_supervises_on_health_id"
+    t.index ["manager_id"], name: "index_supervises_on_manager_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -121,4 +130,6 @@ ActiveRecord::Schema.define(version: 2022_12_25_165254) do
   add_foreign_key "comments", "users"
   add_foreign_key "healths", "care_users"
   add_foreign_key "reserves", "users"
+  add_foreign_key "supervises", "healths"
+  add_foreign_key "supervises", "managers"
 end

--- a/spec/factories/managers.rb
+++ b/spec/factories/managers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :manager do
+    
+  end
+end

--- a/spec/factories/supervises.rb
+++ b/spec/factories/supervises.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :supervise do
+    health { nil }
+    manager { nil }
+  end
+end

--- a/spec/models/manager_spec.rb
+++ b/spec/models/manager_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Manager, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/supervise_spec.rb
+++ b/spec/models/supervise_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Supervise, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- 介護記録と責任者を多対多で関連づけた
- 介護記録登録時、責任者をチェックボックスで選択できるようにした
- ユーザと責任者を1対多で関連付け、ログインしているユーザに紐づいた責任者を登録、編集、削除、一覧表示するように制限をかけた